### PR TITLE
Pin alpine version to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.19
 
 RUN apk --update --no-cache add git aws-cli
 


### PR DESCRIPTION
3.20 does not have the 'aws-cli' as of May 22, 2024.